### PR TITLE
Update LookMl Model to use canceled instead of cancelled

### DIFF
--- a/orders.view.lkml
+++ b/orders.view.lkml
@@ -80,7 +80,7 @@ view: orders {
     group_label: "Dates"
   }
 
-  dimension_group: cancelled {
+  dimension_group: canceled {
     type: time
     timeframes: [
       raw,
@@ -91,7 +91,7 @@ view: orders {
       quarter,
       year
     ]
-    sql: ${TABLE}.cancelled_at ;;
+    sql: ${TABLE}.canceled_at ;;
     group_label: "Dates"
   }
 


### PR DESCRIPTION
I work on the Shopify Data Warehouse team. We are moving towards all American spelling throughout our tables. Next week we will be removing `cancelled_at` from the `orders` table. Both fields contain identical data so all that needs to be changed is the spelling. 
### What?
changed `orders.cancelled_at` to `order.canceled_at`

### Why?
We are removing this field so all reports built of this model will break. We are choosing to use American spelling throughout our tables from now on. 

### Anything could go wrong?
- nope, this field is fully supported and shouldn't change any reports. 

### Docs
https://help.shopify.com/api/data-warehouse/schema-reference/orders
<img width="698" alt="screen shot 2018-01-17 at 3 29 53 pm" src="https://user-images.githubusercontent.com/22918444/35065455-52ae10d2-fb9b-11e7-8b86-08d272208cf0.png">

##### CC
@jthandy @matthelm